### PR TITLE
fix: update speakeasy version to v1.665.0

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -32,7 +32,7 @@ sources-syft:
 sources-speakeasy:
     FROM +base-image
     RUN apk update && apk add yarn jq unzip curl
-    ARG VERSION=v1.351.0
+    ARG VERSION=v1.665.0
     ARG TARGETARCH
     RUN echo $VERSION
     RUN curl -fsSL https://github.com/speakeasy-api/speakeasy/releases/download/${VERSION}/speakeasy_linux_$TARGETARCH.zip -o /tmp/speakeasy_linux_$TARGETARCH.zip


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated Speakeasy CLI version in the Earthfile to v1.665.0, ensuring the sources-speakeasy build stage pulls the latest release during builds.

<sup>Written for commit 5b03b76ff5f8046b9acc51b79fb79be4e09902e6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

