### PR TITLE
fix: fix buildx provenance for multi arch images

### DIFF
--- a/.goreleaser.default.yaml
+++ b/.goreleaser.default.yaml
@@ -38,6 +38,7 @@ dockers:
     dockerfile: build.Dockerfile
     use: buildx
     build_flag_templates:
+      - --provenance=false
       - --platform=linux/amd64
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
@@ -52,6 +53,7 @@ dockers:
     dockerfile: build.Dockerfile
     use: buildx
     build_flag_templates:
+      - --provenance=false
       - --platform=linux/arm64/v8
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
@@ -67,6 +69,7 @@ dockers:
     dockerfile: scratch.Dockerfile
     use: buildx
     build_flag_templates:
+      - --provenance=false
       - --platform=linux/amd64
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
@@ -81,6 +84,7 @@ dockers:
     dockerfile: scratch.Dockerfile
     use: buildx
     build_flag_templates:
+      - --provenance=false
       - --platform=linux/arm64/v8
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}


### PR DESCRIPTION
The problem is: modern docker buildx often pushes a tag as an OCI “image index” (manifest list) even when you build a single platform, because of default attestations/provenance (and sometimes SBOM). When GoReleaser later runs docker manifest create ... <image>-amd64 <image>-arm64, Docker refuses because one (or both) of those inputs is already a manifest list → hence: xxx is a manifest list. This behavior and the workaround are well-documented in Docker/buildx issues and docs.